### PR TITLE
feat(SP-2025-1791): Copy fauthful files in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,31 @@ sincpro-decrypt ./codigo_protegido.enc --password "clave_secreta" -o ./codigo_de
 - **Protección Comercial**: Impide el acceso casual al código .pyc
 - **Flexibilidad**: Elige entre compresión (más compatible) o encriptación (más segura)
 
+### 📦 Copias fieles por template (Nuevo Feature)
+
+A partir de la versión actual, SincPro Python Compiler permite definir archivos y carpetas que serán **copiados fielmente** (sin compilar ni excluir) según el template seleccionado.
+
+Por ejemplo, en el template `odoo`, los siguientes archivos y carpetas se copian tal cual al directorio de salida:
+
+- `__manifest__.py`
+- `__openerp__.py`
+- `static/`
+- `data/`
+- `demo/`
+- `security/`
+
+Esto es útil para mantener la integridad de archivos requeridos por Odoo y otros frameworks, evitando su compilación o exclusión.
+
+### Ejemplo de uso
+
+```bash
+sincpro-compile ./mi_addon_odoo -t odoo
+```
+
+En este caso, los archivos `.py` se compilan a `.pyc`, los archivos definidos como "copias fieles" se copian tal cual, y el resto se excluye según el template.
+
+Puedes personalizar los templates o agregar tus propios patrones en la carpeta `resources/exclude_patterns/`.
+
 ### Uso con diferentes tipos de proyecto
 
 #### Proyecto Python básico

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -235,6 +235,23 @@ flowchart TD
     style E fill:#ffebee
 ```
 
+## 🔧 Lógica de Copias Fieles en la Infraestructura
+
+El flujo de compilación en SincPro Python Compiler ahora incluye la capacidad de **copiar archivos y carpetas fielmente** según patrones definidos en cada template. Esta lógica está implementada en la capa de infraestructura (`PythonCompiler` y `CompilerService`).
+
+- Los archivos y carpetas definidos como "copias fieles" en el template (por ejemplo, `odoo`) se copian tal cual al directorio de salida, sin ser compilados ni excluidos.
+- El resto de archivos `.py` se compilan a `.pyc`.
+- Los patrones de exclusión siguen aplicándose normalmente.
+
+Esta funcionalidad permite mantener la integridad de archivos requeridos por frameworks como Odoo, facilitando la distribución y despliegue sin perder información esencial.
+
+**Ejemplo:**
+
+- Template `odoo`: Copia fiel de `__manifest__.py`, `__openerp__.py`, `static/`, `data/`, `demo/`, `security/`.
+- Template `django`: Excluye carpetas como `migrations/`, `static/`, pero no realiza copias fieles por defecto.
+
+La lógica puede ser extendida o personalizada editando los templates en `resources/exclude_patterns/`.
+
 ## 🧪 Arquitectura de Testing
 
 ```mermaid

--- a/sincpro_py_compiler/infrastructure/compiler_service.py
+++ b/sincpro_py_compiler/infrastructure/compiler_service.py
@@ -6,7 +6,7 @@ import logging
 import os
 import py_compile
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -15,51 +15,61 @@ class CompilerService:
     """Implementación concreta del servicio de compilación"""
 
     def __init__(self):
-        # Templates de exclusión simples
-        self.templates = {
-            "basic": [
-                "__pycache__/",
-                "*.pyc",
-                ".git/",
-                ".venv/",
-                "venv/",
-                "env/",
-                ".env/",
-                "*.log",
-                ".DS_Store",
-            ],
-            "django": [
-                "__pycache__/",
-                "*.pyc",
-                ".git/",
-                ".venv/",
-                "venv/",
-                "env/",
-                ".env/",
-                "*.log",
-                ".DS_Store",
-                "migrations/",
-                "static/",
-                "media/",
-                "db.sqlite3",
-            ],
-            "odoo": [
-                "__pycache__/",
-                "*.pyc",
-                ".git/",
-                ".venv/",
-                "venv/",
-                "env/",
-                ".env/",
-                "*.log",
-                ".DS_Store",
-                "__manifest__.py",
-                "__openerp__.py",
-                "static/",
-                "data/",
-                "demo/",
-                "security/",
-            ],
+        # Templates de exclusión y copia fiel
+        self.templates: Dict[str, Dict[str, List[str]]] = {
+            "basic": {
+                "exclude": [
+                    "__pycache__/",
+                    "*.pyc",
+                    ".git/",
+                    ".venv/",
+                    "venv/",
+                    "env/",
+                    ".env/",
+                    "*.log",
+                    ".DS_Store",
+                ],
+                "copy_faithful": [],
+            },
+            "django": {
+                "exclude": [
+                    "__pycache__/",
+                    "*.pyc",
+                    ".git/",
+                    ".venv/",
+                    "venv/",
+                    "env/",
+                    ".env/",
+                    "*.log",
+                    ".DS_Store",
+                    "migrations/",
+                    "static/",
+                    "media/",
+                    "db.sqlite3",
+                ],
+                "copy_faithful": [],
+            },
+            "odoo": {
+                "exclude": [
+                    "__pycache__/",
+                    "*.pyc",
+                    ".git/",
+                    ".venv/",
+                    "venv/",
+                    "env/",
+                    ".env/",
+                    "*.log",
+                    ".DS_Store",
+                ],
+                "copy_faithful": [
+                    "__manifest__.py",
+                    "__openerp__.py",
+                    "static/",
+                    "data/",
+                    "demo/",
+                    "security/",
+                ],
+            },
         }
 
     def should_exclude(self, file_path: Path, exclude_patterns: List[str]) -> bool:
@@ -82,25 +92,40 @@ class CompilerService:
                     return True
         return False
 
+    def should_copy_faithful(self, file_path: Path, copy_patterns: List[str]) -> bool:
+        """Determina si un archivo debe copiarse fielmente"""
+        file_str = str(file_path)
+        for pattern in copy_patterns:
+            if pattern.endswith("/"):
+                # Es un directorio
+                if f"/{pattern}" in file_str or file_str.startswith(pattern):
+                    return True
+            else:
+                # Es un archivo específico
+                if file_path.name == pattern or file_str.endswith(f"/{pattern}"):
+                    return True
+        return False
+
     def get_exclude_patterns(
         self, template: Optional[str] = None, custom_file: Optional[str] = None
     ) -> List[str]:
         """Obtiene patrones de exclusión"""
         patterns = []
-
-        # Usar template si se especifica
         if template and template in self.templates:
-            patterns.extend(self.templates[template])
-
-        # Leer archivo custom si existe
+            patterns.extend(self.templates[template]["exclude"])
         if custom_file and os.path.exists(custom_file):
             with open(custom_file, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if line and not line.startswith("#"):
                         patterns.append(line)
-
         return patterns
+
+    def get_copy_faithful_patterns(self, template: Optional[str] = None) -> List[str]:
+        """Obtiene patrones de copia fiel"""
+        if template and template in self.templates:
+            return self.templates[template]["copy_faithful"]
+        return []
 
     def compile_python_file(self, source_file: Path, output_file: Path) -> bool:
         """Compila un archivo Python"""

--- a/tests/test_sincpro_compiler.py
+++ b/tests/test_sincpro_compiler.py
@@ -37,12 +37,20 @@ class TestCompilerService:
 
     def test_patrones_template_odoo(self):
         """Test patrones específicos de Odoo"""
-        patterns = self.service.get_exclude_patterns("odoo")
+        exclude_patterns = self.service.get_exclude_patterns("odoo")
+        copy_faithful_patterns = self.service.get_copy_faithful_patterns("odoo")
 
-        assert "__manifest__.py" in patterns
-        assert "__openerp__.py" in patterns
-        assert "static/" in patterns
-        assert "data/" in patterns
+        # Los manifests ya no deben estar en exclusión
+        assert "__manifest__.py" not in exclude_patterns
+        assert "__openerp__.py" not in exclude_patterns
+        # Deben estar en copia fiel
+        assert "__manifest__.py" in copy_faithful_patterns
+        assert "__openerp__.py" in copy_faithful_patterns
+        # Los directorios de datos deben estar en copia fiel
+        assert "static/" in copy_faithful_patterns
+        assert "data/" in copy_faithful_patterns
+        assert "demo/" in copy_faithful_patterns
+        assert "security/" in copy_faithful_patterns
 
     def test_should_exclude_archivo_pyc(self):
         """Test exclusión de archivos .pyc"""
@@ -212,18 +220,18 @@ class TestPythonCompiler:
         assert not (output_dir / "static").exists()
 
     def test_caso_uso_addon_odoo(self):
-        """Test: Compilar addon Odoo excluyendo manifests"""
+        """Test: Compilar addon Odoo copiando manifests y carpetas fielmente"""
         # Crear estructura Odoo
         (self.temp_dir / "models.py").write_text("class Partner: pass")
         (self.temp_dir / "views.py").write_text("# vistas")
         (self.temp_dir / "__manifest__.py").write_text("{'name': 'Mi Addon'}")
 
-        # Archivos de datos (deben excluirse)
+        # Archivos de datos (deben copiarse fielmente)
         data_dir = self.temp_dir / "data"
         data_dir.mkdir()
         (data_dir / "records.xml").write_text("<data></data>")
 
-        # Security (debe excluirse)
+        # Security (debe copiarse fielmente)
         security_dir = self.temp_dir / "security"
         security_dir.mkdir()
         (security_dir / "groups.xml").write_text("<security></security>")
@@ -240,12 +248,10 @@ class TestPythonCompiler:
         assert (output_dir / "models.pyc").exists()
         assert (output_dir / "views.pyc").exists()
 
-        # Manifest excluido (información sensible)
-        assert not (output_dir / "__manifest__.py").exists()
-
-        # Data y security excluidos
-        assert not (output_dir / "data").exists()
-        assert not (output_dir / "security").exists()
+        # Manifest y carpetas deben copiarse fielmente
+        assert (output_dir / "__manifest__.py").exists()
+        assert (output_dir / "data" / "records.xml").exists()
+        assert (output_dir / "security" / "groups.xml").exists()
 
     def test_caso_uso_proyecto_con_estructura_compleja(self):
         """Test: Proyecto con estructura de subdirectorios"""
@@ -331,3 +337,37 @@ secret.py
         assert "django:" in output
         assert "odoo:" in output
         assert "__pycache__/" in output
+
+    def test_copia_fiel_archivos_odoo(self):
+        """Test: Archivos/carpeta de Odoo se copian fielmente"""
+        temp_dir = Path(tempfile.mkdtemp())
+        output_dir = temp_dir / "output"
+        temp_dir.mkdir(exist_ok=True)
+        (temp_dir / "__manifest__.py").write_text("{'name': 'Mi Addon'}")
+        (temp_dir / "__openerp__.py").write_text("{'name': 'Mi Addon'}")
+        static_dir = temp_dir / "static"
+        static_dir.mkdir()
+        (static_dir / "file.js").write_text("console.log('test')")
+        data_dir = temp_dir / "data"
+        data_dir.mkdir()
+        (data_dir / "records.xml").write_text("<data></data>")
+        demo_dir = temp_dir / "demo"
+        demo_dir.mkdir()
+        (demo_dir / "demo.xml").write_text("<demo></demo>")
+        security_dir = temp_dir / "security"
+        security_dir.mkdir()
+        (security_dir / "groups.xml").write_text("<security></security>")
+
+        compiler = PythonCompiler()
+        success = compiler.compile_project(
+            source_dir=str(temp_dir), output_dir=str(output_dir), template="odoo"
+        )
+        assert success
+        # Verificar que los archivos/carpeta se copiaron fielmente
+        assert (output_dir / "__manifest__.py").exists()
+        assert (output_dir / "__openerp__.py").exists()
+        assert (output_dir / "static" / "file.js").exists()
+        assert (output_dir / "data" / "records.xml").exists()
+        assert (output_dir / "demo" / "demo.xml").exists()
+        assert (output_dir / "security" / "groups.xml").exists()
+        shutil.rmtree(temp_dir)


### PR DESCRIPTION
This pull request introduces a new feature to the SincPro Python Compiler: the ability to define "copias fieles" (faithful copies) of files and directories in templates, particularly improving support for Odoo addons. Files and folders marked for faithful copying are transferred as-is to the output directory, without compilation or exclusion, ensuring the integrity of framework-required assets. The change is thoroughly documented and tested, and the infrastructure has been refactored to support this logic for all templates.

**Feature: Faithful Copy Logic for Templates**
- Added support for defining files and folders that are copied without compilation or exclusion, configurable per template (e.g., Odoo) in the infrastructure layer (`CompilerService`, `PythonCompiler`). [[1]](diffhunk://#diff-e5aa1d95778ddc4a7386360c5b563a55f835ba600032cd78644a4631d7b01f8aL18-R21) [[2]](diffhunk://#diff-e5aa1d95778ddc4a7386360c5b563a55f835ba600032cd78644a4631d7b01f8aR63-R72) [[3]](diffhunk://#diff-18406986673a15d708719117c0f86e7928eb73574d4eaf8d2d90f32dc21f3b96R90-R98)

**Documentation Updates**
- Updated `README.md` and `docs/ARCHITECTURE.md` to describe the new "copias fieles" feature, its use cases, and examples for Odoo and Django templates. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R88-R112) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R238-R254)

**Testing Enhancements**
- Refactored and expanded tests to verify correct handling of faithful copies for Odoo projects, ensuring manifests and data/security folders are copied as expected and not excluded. Added new tests for template pattern logic and faithful copy behavior. [[1]](diffhunk://#diff-5d25aa524335d48cc0c406b898b89902ad290c5cb60951b6120ca3c49883e83dL40-R53) [[2]](diffhunk://#diff-5d25aa524335d48cc0c406b898b89902ad290c5cb60951b6120ca3c49883e83dL215-R234) [[3]](diffhunk://#diff-5d25aa524335d48cc0c406b898b89902ad290c5cb60951b6120ca3c49883e83dL243-R254) [[4]](diffhunk://#diff-5d25aa524335d48cc0c406b898b89902ad290c5cb60951b6120ca3c49883e83dR340-R373)

**Refactor: Template Configuration**
- Changed template configuration structure to support both exclusion and faithful copy patterns, making it extensible for future templates. [[1]](diffhunk://#diff-e5aa1d95778ddc4a7386360c5b563a55f835ba600032cd78644a4631d7b01f8aL18-R21) [[2]](diffhunk://#diff-e5aa1d95778ddc4a7386360c5b563a55f835ba600032cd78644a4631d7b01f8aL31-R35) [[3]](diffhunk://#diff-e5aa1d95778ddc4a7386360c5b563a55f835ba600032cd78644a4631d7b01f8aL46-R53)

**Internal API Changes**
- Added methods to retrieve and match faithful copy patterns, and updated compilation logic to handle faithful copying before exclusion and compilation. [[1]](diffhunk://#diff-e5aa1d95778ddc4a7386360c5b563a55f835ba600032cd78644a4631d7b01f8aR95-R129) [[2]](diffhunk://#diff-18406986673a15d708719117c0f86e7928eb73574d4eaf8d2d90f32dc21f3b96L60-R69)

These changes make the compiler more flexible and reliable for real-world Python frameworks, especially Odoo, and lay the groundwork for further template-based customizations.